### PR TITLE
Replace gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var through2    = require('through2');
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 var bufferMode  = require('./lib/buffer');
 var streamMode  = require('./lib/stream');
 var defaults = require('defaults');

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   "dependencies": {
     "bytes": "^2.1.0",
     "defaults": "^1.0.2",
-    "gulp-util": "^3.0.4",
+    "fancy-log": "^1.3.2",
     "node-zopfli": "^1.2.1",
+    "plugin-error": "^1.0.1",
     "stream-to-array": "^2.0.2",
     "through2": "^2.0.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var fs     = require('fs');
 var gulp   = require('gulp');
-var log    = require('gulp-util').log;
+var log    = require('fancy-log');
 var zopfli = require('../');
 var nid    = require('nid');
 var rename = require('gulp-rename');


### PR DESCRIPTION
`gulp-util` is deprecated and should no longer be used.

See https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5